### PR TITLE
Local Notesの見出しを細めのウェイトに変更

### DIFF
--- a/src/components/note-grid.tsx
+++ b/src/components/note-grid.tsx
@@ -41,9 +41,7 @@ export function NoteGrid() {
     return notes.filter((note) => {
       const normalizedTitle = normalizeForSearch(note.title);
       const normalizedBody = normalizeForSearch(note.body);
-      return (
-        normalizedTitle.includes(query) || normalizedBody.includes(query)
-      );
+      return normalizedTitle.includes(query) || normalizedBody.includes(query);
     });
   }, [notes, searchQuery]);
 

--- a/src/components/page-header.tsx
+++ b/src/components/page-header.tsx
@@ -3,7 +3,7 @@ import { SearchBar } from "./search-bar";
 export function PageHeader() {
   return (
     <div>
-      <h1 className="text-3xl font-bold text-center mb-8">Local Notes</h1>
+      <h1 className="text-3xl font-medium text-center mb-8">Local Notes</h1>
       <SearchBar />
     </div>
   );


### PR DESCRIPTION
## 目的
- 見出しが太すぎるとのフィードバックへの対応

## 変更内容
- PageHeaderの`Local Notes`見出しを`font-medium`に変更

## チェックリスト
- [x] スタイルのみの変更で追加テストは不要